### PR TITLE
normalize output of go parser to match tests

### DIFF
--- a/scripts/test-one-go.go
+++ b/scripts/test-one-go.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -22,5 +23,12 @@ func main() {
 	data := microformats.Parse(f, baseURL)
 
 	json, _ := json.MarshalIndent(data, "", "  ")
+
+	// unescape apostophes that golang.org/x/net/html insists on escpaing
+	json = bytes.Replace(json, []byte(`\u0026#39;`), []byte(`'`), -1)
+	// golang.org/x/net/html doesn't put a space at the end of self-closing
+	// tags, but at least one test case expects it.
+	json = bytes.Replace(json, []byte(`"/>`), []byte(`" />`), -1)
+
 	fmt.Println(string(json))
 }


### PR DESCRIPTION
This normalizes two cases where the output of the go library differs from the expected test results in non-meaningful ways:

 - the underlying go html library always wants to encode apostrophes `'` as `&#39;` for whatever reason.

 - the go html library does not include a space before the closing `/` in a self-closing element.  Both are of course valid HTML, with or without the space.  All of the major libraries have this problem with the exception of Node (which makes sense, given that these tests were originally written against that library):

   - [go](https://ben.thatmustbe.me/mf2tests/go/microformats-v2/h-entry/urlincontent.json.diff.txt) and [python](https://ben.thatmustbe.me/mf2tests/python/microformats-v2/h-entry/urlincontent.json.diff.txt) render as `<img src=""/>`
   - [php](https://ben.thatmustbe.me/mf2tests/php/microformats-v2/h-entry/urlincontent.json.diff.txt) and [ruby](https://ben.thatmustbe.me/mf2tests/ruby/microformats-v2/h-entry/urlincontent.json.diff.txt) render as `<img src="">`

  I'm not sure of the best way to handle this one for all the libraries other than to modify each of their `test-all-*` scripts like this?